### PR TITLE
Prevent the border from being drawn outside the widget.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,7 @@ class MyApp extends StatelessWidget {
                 spacing: 8,
                 children: <Widget>[
                   rectBorderWidget,
+                  rectBorderWithPaddingWidget,
                   roundedRectBorderWidget,
                   customBorder,
                   roundStrokeCap,
@@ -45,6 +46,24 @@ class MyApp extends StatelessWidget {
         height: 200,
         width: 120,
         color: Colors.red,
+      ),
+    );
+  }
+
+  /// Use [DottedBorder.borderPadding] to prevent the border from being drawn outside the widget.
+  Widget get rectBorderWithPaddingWidget {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: DottedBorder(
+        dashPattern: [8, 4],
+        strokeWidth: 8,
+        padding: EdgeInsets.all(8),
+        borderPadding: EdgeInsets.all(4),
+        child: Container(
+          height: 200,
+          width: 120,
+          color: Colors.red.withOpacity(0.5),
+        ),
       ),
     );
   }

--- a/lib/dash_painter.dart
+++ b/lib/dash_painter.dart
@@ -10,6 +10,7 @@ class _DashPainter extends CustomPainter {
   final Radius radius;
   final StrokeCap strokeCap;
   final PathBuilder? customPath;
+  final EdgeInsets padding;
 
   _DashPainter({
     this.strokeWidth = 2,
@@ -19,12 +20,24 @@ class _DashPainter extends CustomPainter {
     this.radius = const Radius.circular(0),
     this.strokeCap = StrokeCap.butt,
     this.customPath,
+    this.padding = EdgeInsets.zero,
   }) {
     assert(dashPattern.isNotEmpty, 'Dash Pattern cannot be empty');
   }
 
   @override
-  void paint(Canvas canvas, Size size) {
+  void paint(Canvas canvas, Size originalSize) {
+    final Size size;
+    if (padding == EdgeInsets.zero) {
+      size = originalSize;
+    } else {
+      canvas.translate(padding.left, padding.top);
+      size = Size(
+        originalSize.width - padding.horizontal,
+        originalSize.height - padding.vertical,
+      );
+    }
+
     Paint paint = Paint()
       ..strokeWidth = strokeWidth
       ..color = color
@@ -132,6 +145,7 @@ class _DashPainter extends CustomPainter {
     return oldDelegate.strokeWidth != this.strokeWidth ||
         oldDelegate.color != this.color ||
         oldDelegate.dashPattern != this.dashPattern ||
+        oldDelegate.padding != this.padding ||
         oldDelegate.borderType != this.borderType;
   }
 }

--- a/lib/dotted_border.dart
+++ b/lib/dotted_border.dart
@@ -14,6 +14,7 @@ part 'dash_painter.dart';
 class DottedBorder extends StatelessWidget {
   final Widget child;
   final EdgeInsets padding;
+  final EdgeInsets borderPadding;
   final double strokeWidth;
   final Color color;
   final List<double> dashPattern;
@@ -29,6 +30,7 @@ class DottedBorder extends StatelessWidget {
     this.borderType = BorderType.Rect,
     this.dashPattern = const <double>[3, 1],
     this.padding = const EdgeInsets.all(2),
+    this.borderPadding = EdgeInsets.zero,
     this.radius = const Radius.circular(0),
     this.strokeCap = StrokeCap.butt,
     this.customPath,
@@ -43,6 +45,7 @@ class DottedBorder extends StatelessWidget {
         Positioned.fill(
           child: CustomPaint(
             painter: _DashPainter(
+              padding: borderPadding,
               strokeWidth: strokeWidth,
               radius: radius,
               color: color,


### PR DESCRIPTION
Add `borderPadding` to prevent the border from being drawn outside the widget.
