### PR TITLE
Swap the order the border and child is drawn

### DIFF
--- a/lib/dotted_border.dart
+++ b/lib/dotted_border.dart
@@ -52,17 +52,19 @@ class DottedBorder extends StatelessWidget {
           child: child,
         ),
         Positioned.fill(
-          child: CustomPaint(
-            painter: DashedPainter(
-              padding: borderPadding,
-              strokeWidth: strokeWidth,
-              radius: radius,
-              color: color,
-              gradient: gradient,
-              borderType: borderType,
-              dashPattern: dashPattern,
-              customPath: customPath,
-              strokeCap: strokeCap,
+          child: IgnorePointer(
+            child: CustomPaint(
+              painter: DashedPainter(
+                padding: borderPadding,
+                strokeWidth: strokeWidth,
+                radius: radius,
+                color: color,
+                gradient: gradient,
+                borderType: borderType,
+                dashPattern: dashPattern,
+                customPath: customPath,
+                strokeCap: strokeCap,
+              ),
             ),
           ),
         ),

--- a/lib/dotted_border.dart
+++ b/lib/dotted_border.dart
@@ -47,6 +47,10 @@ class DottedBorder extends StatelessWidget {
     return Stack(
       fit: stackFit,
       children: <Widget>[
+        Padding(
+          padding: padding,
+          child: child,
+        ),
         Positioned.fill(
           child: CustomPaint(
             painter: DashedPainter(
@@ -61,10 +65,6 @@ class DottedBorder extends StatelessWidget {
               strokeCap: strokeCap,
             ),
           ),
-        ),
-        Padding(
-          padding: padding,
-          child: child,
         ),
       ],
     );


### PR DESCRIPTION
Change required to fix this [issue](https://github.com/ajilo297/Flutter-Dotted-Border/issues/32).